### PR TITLE
Update GitHub Actions workflow to use OIDC with github-actions-role

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
+          role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-role
           role-session-name: GitHubActions
           aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
This pull request updates the AWS credentials configuration in the GitHub Actions workflow to include a role assumption step.

* [`.github/workflows/hugo.yml`](diffhunk://#diff-40a02c7a31ca0437cb4d959a3c117788bbb41ae8d4a39d4a995db6271b9887e3R39): Added the `role-to-assume` parameter to specify the AWS IAM role (`arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/github-actions-role`) for GitHub Actions to assume during execution.